### PR TITLE
feat: 티켓 토큰 조회 기능 추가

### DIFF
--- a/src/main/java/org/muses/backendbulidtest251228/domain/checkin/controller/CheckinCTL.java
+++ b/src/main/java/org/muses/backendbulidtest251228/domain/checkin/controller/CheckinCTL.java
@@ -20,6 +20,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Tag(
@@ -107,6 +108,25 @@ public class CheckinCTL {
                 .contentType(MediaType.IMAGE_PNG)
                 .cacheControl(CacheControl.noStore())
                 .body(png);
+    }
+
+    @Operation(
+            summary = "티켓 토큰 조회",
+            description = "티켓 ID를 통해 체크인에 사용되는 ticketToken을 조회합니다."
+    )
+    @GetMapping("/tickets/{ticketId}")
+    public ApiResponse<Map<String, Object>> getToken(
+            @PathVariable Long ticketId
+    ) {
+        TicketENT ticket = ticketRepo.findById(ticketId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 티켓"));
+
+        String ticketToken = ticket.getTicketToken();
+
+
+        return ApiResponse.success(Map.of(
+                "ticketToken", ticketToken
+        ));
     }
 
 


### PR DESCRIPTION
## 관련 이슈
- close #66 

## 변경 내용
- 티켓 토큰 api 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 티켓 토큰 조회 기능이 추가되었습니다. 사용자는 이제 티켓 ID를 통해 해당 티켓의 토큰 정보를 간편하게 조회할 수 있습니다. 존재하는 티켓의 토큰 정보가 빠르게 반환되며, 유효하지 않은 티켓 요청 시에는 적절한 오류 응답이 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->