### PR TITLE
fix: id 값 1개로 제한

### DIFF
--- a/src/main/java/org/muses/backendbulidtest251228/domain/event/repository/EventRepo.java
+++ b/src/main/java/org/muses/backendbulidtest251228/domain/event/repository/EventRepo.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface EventRepo extends JpaRepository<Event, Long> {
@@ -48,37 +49,36 @@ public interface EventRepo extends JpaRepository<Event, Long> {
 
 
 
-    // prev = 더 최근(업로드시간 더 큼) 중 가장 가까운 1개
     @Query("""
-        select e.id
-        from Event e
-        where e.uploadDateTime <= current_timestamp
-          and (
-                e.uploadDateTime > :currentUpload
-                or (e.uploadDateTime = :currentUpload and e.id > :currentId)
-          )
-        order by e.uploadDateTime asc, e.id asc
-    """)
-    Optional<Long> findPrevId(
+    select e.id
+    from Event e
+    where e.uploadDateTime <= current_timestamp
+      and (
+            e.uploadDateTime > :currentUpload
+            or (e.uploadDateTime = :currentUpload and e.id > :currentId)
+      )
+    order by e.uploadDateTime asc, e.id asc
+""")
+    List<Long> findPrevIds(
             @Param("currentUpload") LocalDateTime currentUpload,
             @Param("currentId") Long currentId,
             Pageable pageable
     );
 
-    // next = 더 오래된(업로드시간 더 작음) 중 가장 가까운 1개
     @Query("""
-        select e.id
-        from Event e
-        where e.uploadDateTime <= current_timestamp
-          and (
-                e.uploadDateTime < :currentUpload
-                or (e.uploadDateTime = :currentUpload and e.id < :currentId)
-          )
-        order by e.uploadDateTime desc, e.id desc
-    """)
-    Optional<Long> findNextId(
+    select e.id
+    from Event e
+    where e.uploadDateTime <= current_timestamp
+      and (
+            e.uploadDateTime < :currentUpload
+            or (e.uploadDateTime = :currentUpload and e.id < :currentId)
+      )
+    order by e.uploadDateTime desc, e.id desc
+""")
+    List<Long> findNextIds(
             @Param("currentUpload") LocalDateTime currentUpload,
             @Param("currentId") Long currentId,
             Pageable pageable
     );
+
 }

--- a/src/main/java/org/muses/backendbulidtest251228/domain/event/service/EventSRV.java
+++ b/src/main/java/org/muses/backendbulidtest251228/domain/event/service/EventSRV.java
@@ -60,12 +60,12 @@ public class EventSRV {
         );
 
         Long prevId = eventRepo
-                .findPrevId(event.getUploadDateTime(), event.getId(), PageRequest.of(0, 1))
-                .orElse(null);
+                .findPrevIds(event.getUploadDateTime(), event.getId(), PageRequest.of(0, 1))
+                .stream().findFirst().orElse(null);
 
         Long nextId = eventRepo
-                .findNextId(event.getUploadDateTime(), event.getId(), PageRequest.of(0, 1))
-                .orElse(null);
+                .findNextIds(event.getUploadDateTime(), event.getId(), PageRequest.of(0, 1))
+                .stream().findFirst().orElse(null);
 
         EventDetailResDTO res = new EventDetailResDTO(eventDto, prevId, nextId);
 


### PR DESCRIPTION
## 관련 이슈
- close #83 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 이벤트 탐색에서 이전/다음 항목을 가져올 때 페이지네이션을 활용하도록 개선되어 성능 및 결과 제어가 향상되었습니다.
  * 여러 후보 중에서 필요한 항목을 선택해 응답에 반영하므로 탐색 안정성이 향상되었습니다.

* **리팩토링**
  * 이전/다음 이벤트 조회 로직이 페이지 단위 조회로 정리되어 유지보수성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->